### PR TITLE
Reset Transpile State

### DIFF
--- a/src/typescript/typescript-to-typebox.ts
+++ b/src/typescript/typescript-to-typebox.ts
@@ -465,6 +465,7 @@ export namespace TypeScriptToTypeBox {
     typeNames.clear()
     useImports = false
     useGenerics = false
+    useTypeClone = false
     const source = ts.createSourceFile('types.ts', typescriptCode, ts.ScriptTarget.ESNext, true)
     const declarations = Formatter.Format([...Visit(source)].join('\n\n'))
     const imports = ImportStatement(options)


### PR DESCRIPTION
PR to set the `useTypeClone` state on `TypeScriptToTypeBox` transpilation.