### PR TITLE
fix(valibot): fix record type parameters

### DIFF
--- a/src/model/model-to-valibot.ts
+++ b/src/model/model-to-valibot.ts
@@ -126,9 +126,9 @@ export namespace ModelToValibot {
     for (const [key, value] of globalThis.Object.entries(schema.patternProperties)) {
       const type = Visit(value)
       if (key === `^(0|[1-9][0-9]*)$`) {
-        return UnsupportedType(schema)
+        return Type('v.record', `v.number(), ${type}`, [])
       } else {
-        return Type(`v.record`, type, [])
+        return Type(`v.record`, `v.string(), ${type}`, [])
       }
     }
     throw Error(`Unreachable`)


### PR DESCRIPTION
Related PR: https://github.com/sinclairzx81/typebox-codegen/pull/44

It wasn't mentioned in [the migration guide](https://valibot.dev/guides/migrate-to-v0.31.0), but the parameters of `record` also needed to be changed.

```ts
Current:

export type T = Record<string, unknown>

↓

export type T = v.InferOutput<typeof T>
export const T = v.record(v.unknown()) // ← tsc error: Expected 2-3 arguments, but got 1.(2554)
```

https://valibot.dev/api/record

The `record` schema takes 2-3 parameters: `key`, `value`, and an optional `message`, so I changed it accordingly.

It will now be output as follows:

```ts
Current:

export type T1 = Record<string, unknown>
export type T2 = Record<number, unknown>

↓

export type T1 = v.InferOutput<typeof T1>
export const T1 = v.record(v.string(), v.unknown())

export type T2 = v.InferOutput<typeof T2>
export const T2 = v.record(v.number(), v.unknown())
```

Thank you!