### PR TITLE
fix(arktype): export on model to arktype

### DIFF
--- a/src/model/model-to-arktype.ts
+++ b/src/model/model-to-arktype.ts
@@ -255,7 +255,7 @@ export namespace ModelToArkType {
     for (const type of model.types.filter((type) => Types.TypeGuard.IsSchema(type))) {
       buffer.push(`${GenerateType(type, model.types)},`)
     }
-    buffer.push('}).compile()')
+    buffer.push('}).export()')
     buffer.push('\n')
     for (const type of model.types.filter((type) => Types.TypeGuard.IsSchema(type))) {
       buffer.push(`export type ${type.$id} = typeof ${type.$id}.infer`)


### PR DESCRIPTION
The `compile` method on the `scope` object  has been renamed to `export` in newer versions (2.x.x) of `arktype`.