### PR TITLE
fix(zod): fix zod import for ESM + nodenext

### DIFF
--- a/src/model/model-to-zod.ts
+++ b/src/model/model-to-zod.ts
@@ -239,7 +239,7 @@ export namespace ModelToZod {
     reference_map.clear()
     recursive_set.clear()
     emitted_set.clear()
-    const buffer: string[] = [`import z from 'zod'`, '']
+    const buffer: string[] = [`import { z } from 'zod'`, '']
     for (const type of model.types.filter((type) => Types.TypeGuard.IsSchema(type))) {
       buffer.push(GenerateType(model, type, model.types))
     }


### PR DESCRIPTION
In https://github.com/colinhacks/zod/pull/1067 an additional indirection was added to the zod typing, but the 'default' export does not get re-exported.

This becomes relevant when using moduleResolution options that use the conditional package.json exports, leading to errors since the generated code uses the default export, but that does not get re-exported.

The named export is older than the default export, so this shouldnt break any existing code.