### PR TITLE
fix(arktype): support object type chain

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -22,10 +22,14 @@ export type B = {
   a: number,
   b: string,
   c: boolean
-} 
-export type T = A & B 
+}
+export type T = A & B
 
 export type F = (a: number) => void
+
+export type C = {
+  f: { [key: string]: any } | undefined;
+}
 
 type M = {[K in keyof T]: 1 }
 `


### PR DESCRIPTION
Attempt to close https://github.com/sinclairzx81/typebox-codegen/issues/59.

Arktype supports a plain, non-string literal wrapped inside of `type` calls like

```
type({
  p: {}
})

```

but can't create chained (union / intersection) from object types like

```
type({
 p: '{} | undefined' //won't work, '{}' is not resolvable primitives in arktype
})
```

PR attempts to fix it by changing `Object` codegen, create a `type({})` instead. For the unions and intersections, uses `.or()` / `.intersection()` api chain instead of string literal if the left hand expr started with `type()` calls.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
